### PR TITLE
Fix user_info method for Add to Slack

### DIFF
--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -76,7 +76,7 @@ module OmniAuth
 
       def user_info
         url = URI.parse('/api/users.info')
-        url.query = Rack::Utils.build_query(user: user_identity['id'])
+        url.query = Rack::Utils.build_query(user: user_identity['id'] || access_token.params["user_id"])
         url = url.to_s
 
         @user_info ||= access_token.get(url).parsed


### PR DESCRIPTION
- When going through the standard Add to Slack authentication procedure, the user_identity["id"] is empty because you can't mix the identity.basic scopes with other team wide scopes. Luckily, Slack returns the current logged in users id in the access_token params object, so we should use that if user_identity["id"] is nil
